### PR TITLE
Update angular-modal-service.js

### DIFF
--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -70,21 +70,22 @@
             //  Create a new scope for the modal.
             var modalScope = $rootScope.$new();
 
-            //  Create the inputs object to the controller - this will include
-            //  the scope, as well as all inputs provided.
             //  We will also create a deferred that is resolved with a provided
             //  close function. The controller can then call 'close(result)'.
-            //  The controller can also provide a delay for closing - this is 
+            //  The controller can also provide a delay for closing - this is
             //  helpful if there are closing animations which must finish first.
             var closeDeferred = $q.defer();
-            var inputs = {
-              $scope: modalScope,
-              close: function(result, delay) {
+            angular.extend(modalScope, {closeModal: function(result, delay) {
                 if(delay === undefined || delay === null) delay = 0;
                 $timeout(function () {
                   closeDeferred.resolve(result);
                 }, delay);
-              }
+              }});
+
+            //  Create the inputs object to the controller - this will include
+            //  the scope, as well as all inputs provided.
+            var inputs = {
+              $scope: modalScope
             };
 
             //  If we have provided any inputs, pass them to the controller.
@@ -120,11 +121,11 @@
               controller: modalController,
               scope: modalScope,
               element: modalElement,
-              close: closeDeferred.promise
+              onClose: closeDeferred.promise
             };
 
             //  When close is resolved, we'll clean up the scope and element.
-            modal.close.then(function(result) {
+            modal.onClose.then(function(result) {
               //  Clean up the scope
               modalScope.$destroy();
               //  Remove the element from the dom.


### PR DESCRIPTION
remove "close" as controller parameter and add in Scope with new name: closeModal
return promise change name "close" to "onClose".

Good change if you have a controller to access like:
/products/product/show
and via modal, like me, because if you access via URL you get error: 
Error: [$injector:unpr] Unknown provider: closeProvider <- close

Example with new format:
ON CALLER CONTROLLER:

```
            ModalService.showModal({
                templateUrl: "views/products/product.show.modal.html",
                controller: "ProductsProductController",
                init: {
                    action: 'show'
                }
            }).then(function(modal) {
                modal.element.modal();
                modal.onClose.then(function(result) {
                    console.log('closed');
                    console.log(result); //RETURN  {name: 'test'}
                });
            });
```

ON TARGET CONTROLLER:

```
        $scope.close = function() {
            $scope.closeModal({
                name: 'test'
            }, 500); // close, but give 500ms for bootstrap to animate
        }
```

ON HTML MODAL CODE:

&lt;button type="button" class="btn btn-effect-ripple btn-danger" ng-click="close()"  data-dismiss="modal"&gt;Close&lt;/button&gt;
