### PR TITLE
Fix for not properly closed modal

### DIFF
--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -128,7 +128,10 @@
               //  Clean up the scope
               modalScope.$destroy();
               //  Remove the element from the dom.
-              modalElement.remove();
+              modalElement.modal('hide');
+              modalElement.on('hidden.bs.modal', function () {
+                  modalElement.remove();
+              });
             });
 
             deferred.resolve(modal);


### PR DESCRIPTION
After modal was removed from DOM, there was still possibility that "modal-open" class was left on body element. It happened only in case if modal buttons didn't have data-dismiss="modal" attribute. This fix triggers normal bootstrap hiding process and removes element from DOM afterwards.