### PR TITLE
Fix scope removing on modal close

### DIFF
--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -74,7 +74,7 @@
           .then(function(template) {
 
             //  Create a new scope for the modal.
-            var modalScope = options.scope || $rootScope.$new();
+            var modalScope = (options.scope || $rootScope).$new();
 
             //  Create the inputs object to the controller - this will include
             //  the scope, as well as all inputs provided.


### PR DESCRIPTION
Fix for [issue #50](https://github.com/dwmkerr/angular-modal-service/issues/50). Now modal close doesn't destroy passed scope.