### PR TITLE
Optional scope support

### DIFF
--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -73,7 +73,7 @@
           .then(function(template) {
 
             //  Create a new scope for the modal.
-            var modalScope = $rootScope.$new();
+            var modalScope = (options.scope || $rootScope).$new();
 
             //  Create the inputs object to the controller - this will include
             //  the scope, as well as all inputs provided.


### PR DESCRIPTION
Add scope option for passing custom scope into modal controller.

I moved this update into separate commit from [this](https://github.com/rumkin/angular-modal-service/commit/129c11d1def7054806c925ed7864c14feed9dd64).

This commit solves [issue #50](https://github.com/dwmkerr/angular-modal-service/issues/50) also.