### PR TITLE
allow to use jquery version 1.11.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,12 +31,9 @@
   "dependencies": {
     "angular": "~1.3.x",
     "bootstrap": "~3.3.2",
-    "jquery": "~2.1.3"
+    "jquery": "~1.11.2"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.x"
-  },
-  "resolutions": {
-    "angular": "~1.3.x"
   }
 }


### PR DESCRIPTION
Hello

I my project I use angular 1.3.16 with jquery 1.11.2

I have created this PL to make your angular-modal-service compatible with this version. So far it works like a charm :)

Signed-off-by: Gaetan Semet <gaetan.semet@intel.com>