### PR TITLE
Added autofocus support for input items in modal template

### DIFF
--- a/samples/complex/complex.html
+++ b/samples/complex/complex.html
@@ -13,7 +13,7 @@
 		  <div class="form-group">
 		    <label for="name" class="col-sm-2 control-label">Name</label>
 		    <div class="col-sm-10">
-		      <input type="text" class="form-control" id="name" placeholder="Your Name" ng-model="name">
+		      <input autofocus type="text" class="form-control" id="name" placeholder="Your Name" ng-model="name">
 		    </div>
 		  </div>
 		  <div class="form-group">

--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -136,6 +136,19 @@
               body.append(modalElement);
             }
 
+            ///////////////////////////////
+            setTimeout(function(){
+              var inputs, index;
+
+              inputs = document.getElementsByTagName('input');
+              for (index = 0; index < inputs.length; ++index) {
+                if (inputs[index].attributes.getNamedItem('autofocus')){
+                  inputs[index].focus();
+                }
+              }
+            },300);
+            ///////////////////////////////
+
             //  We now have a modal object...
             var modal = {
               controller: modalController,


### PR DESCRIPTION
I'm new to Angular and Bootstrap and was looking at this modal service. It mostly does what I wanted but it would only autofocus the input box the first time it appeared. I have added some code that looks for any inputs with the autofocus attribute, if it finds one then it focuses it.

At the moment this relies on a timeout. It doesn't work without the timeout but there may be a better way to get it to happen at the correct time, I don't know enough about angular or bootstrap to be able to come up with a better way.

The complex example should now autofocus the name box.