### PR TITLE
Added the capability of handling a controller function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,22 @@ app.controler('ExampleController', function($scope, name, year, close) {
 });
 ```
 
+You can also provide a controller function directly to the modal, with or without the controllerAs attribute :
+
+```js
+ModalService.showModal({
+  template: "<div>Fry lives in {{futurama.city}}</div>",
+  controller: function() {
+    this.city = "New New York";
+  },
+  controllerAs : "futurama"
+})
+```
 #### ShowModal Options
 
 The `showModal` function takes an object with these fields:
 
-* `controller`: The name of the controller to created.
+* `controller`: The name of the controller to created. It could be a function.
 * `controllerAs` : The name of the variable on the scope the controller is assigned to - (optional).
 * `templateUrl`: The URL of the HTML template to use for the modal.
 * `template`: If `templateUrl` is not specified, you can specify `template` as raw
@@ -216,14 +227,14 @@ to manually close the modal. Then call the `close` function as normal:
 
 ```js
 app.controller('ExampleModalController', [
-  '$scope', '$element', 'close', 
+  '$scope', '$element', 'close',
   function($scope, $element, close) {
 
   $scope.closeModal = function() {
 
     //  Manually hide the modal using bootstrap.
     $element.modal('hide');
-    
+
     //  Now close as normal, but give 500ms for bootstrap to animate
     close(null, 500);
   };

--- a/dst/angular-modal-service.js
+++ b/dst/angular-modal-service.js
@@ -64,7 +64,7 @@
 
         //  If a 'controllerAs' option has been provided, we change the controller
         //  name to use 'as' syntax. $controller will automatically handle this.
-        if(options.controllerAs) {
+        if(typeof controllerName === "string" && options.controllerAs) {
           controllerName = controllerName + " as " + options.controllerAs;
         }
 

--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -62,12 +62,6 @@
           return deferred.promise;
         }
 
-        //  If a 'controllerAs' option has been provided, we change the controller
-        //  name to use 'as' syntax. $controller will automatically handle this.
-        if(options.controllerAs) {
-          controllerName = controllerName + " as " + options.controllerAs;
-        }
-
         //  Get the actual html of the template.
         getTemplate(options.template, options.templateUrl)
           .then(function(template) {
@@ -93,9 +87,9 @@
                   //  We can now clean up the scope and remove the element from the DOM.
                   modalScope.$destroy();
                   modalElement.remove();
-                  
+
                   //  Unless we null out all of these objects we seem to suffer
-                  //  from memory leaks, if anyone can explain why then I'd 
+                  //  from memory leaks, if anyone can explain why then I'd
                   //  be very interested to know.
                   inputs.close = null;
                   deferred = null;
@@ -125,8 +119,11 @@
             inputs.$element = modalElement;
 
             //  Create the controller, explicitly specifying the scope to use.
-            var modalController = $controller(controllerName, inputs);
+            var modalController = $controller(options.controller, inputs);
 
+            if(options.controllerAs){
+              modalScope[options.controllerAs] = modalController ;
+            }
             //  Finally, append the modal to the dom.
             if (options.appendElement) {
               // append to custom append element

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -34,7 +34,7 @@ describe('controller', function() {
     $httpBackend.verifyNoOutstandingExpectation();
     $httpBackend.verifyNoOutstandingRequest();
   });
- 
+
   it('should inject the close function into the controller', function() {
 
     $httpBackend.expectGET('some/controllertemplate.html');
@@ -43,7 +43,7 @@ describe('controller', function() {
       controller: "CloseController",
       templateUrl: "some/controllertemplate.html"
     }).then(function(modal) {
-      
+
       //  The controller we've created should put the close function on
       //  the scope, this is how we test it's been passed.
       expect(modal.scope.close).not.toBeUndefined();
@@ -51,7 +51,7 @@ describe('controller', function() {
     });
 
     $httpBackend.flush();
-  
+
   });
 
   it('should inject inputs to the controller', function() {
@@ -66,7 +66,7 @@ describe('controller', function() {
         input2: "hi"
       }
     }).then(function(modal) {
-      
+
       //  The controller sets the inputs on the scope.
       expect(modal.scope.input1).toBe(15);
       expect(modal.scope.input2).toBe("hi");
@@ -86,11 +86,11 @@ describe('controller', function() {
       controllerAs: 'futurama',
       templateUrl: 'some/controllertemplate.html'
     }).then(function(modal) {
-      
+
       //  The controller should be on the scope.
       expect(modal.scope.futurama).not.toBeNull();
 
-      //  Fields defined on the controller instance should be on the 
+      //  Fields defined on the controller instance should be on the
       //  controller on the scope.
       expect(modal.scope.futurama.character).toBe('Fry');
 
@@ -99,7 +99,50 @@ describe('controller', function() {
     $httpBackend.flush();
 
   });
+  it('should add a controller to the scope if the controller is inlined', function() {
 
+    $httpBackend.expectGET('some/controllertemplate.html');
+
+    ModalService.showModal({
+      controller: function($scope){
+        $scope.character = "Fry";
+      },
+      templateUrl: 'some/controllertemplate.html'
+    }).then(function(modal) {
+
+
+      expect(modal.scope).not.toBeNull();
+      expect(modal.scope.character).toBe('Fry');
+
+    });
+
+    $httpBackend.flush();
+
+  });
+  it('should add a controller to the scope if the controller is inlined with controllerAs', function() {
+
+    $httpBackend.expectGET('some/controllertemplate.html');
+
+    ModalService.showModal({
+      controller: function(){
+        this.character = "Fry";
+      },
+      controllerAs: 'futurama',
+      templateUrl: 'some/controllertemplate.html'
+    }).then(function(modal) {
+
+      //  The controller should be on the scope.
+      expect(modal.scope.futurama).not.toBeNull();
+
+      //  Fields defined on the controller instance should be on the
+      //  controller on the scope.
+      expect(modal.scope.futurama.character).toBe('Fry');
+
+    });
+
+    $httpBackend.flush();
+
+  });
   it('should inject the modal element into the controller', function() {
 
     $httpBackend.expectGET('some/controllertemplate.html');
@@ -108,7 +151,7 @@ describe('controller', function() {
       controller: 'ElementController',
       templateUrl: 'some/controllertemplate.html'
     }).then(function(modal) {
-      
+
       //  The controller should be on the scope.
       expect(modal.scope.getElement()).not.toBeUndefined();
 

--- a/test/parameters.spec.js
+++ b/test/parameters.spec.js
@@ -16,7 +16,7 @@ describe('parameters', function() {
       rootScope = $rootScope;
     });
   });
- 
+
   it('should fail if there is no controller specified', function(done) {
 
     ModalService.showModal({
@@ -68,4 +68,20 @@ describe('parameters', function() {
 
   });
 
+  it('should accept the controller provided as a function', function(done) {
+
+    ModalService.showModal({
+      controller: function($scope){
+        $scope.test = "here";
+      },
+      template: "<div>A template</div>"
+    }).then(function(modal) {
+      expect(modal.element.html()).toBe("A template");
+      done();
+    });
+
+
+    rootScope.$apply();
+
+  });
 });


### PR DESCRIPTION
With this PR Modal service can instantiate a controller without having to create it before with angular.controller(...) by passing the controller function directly to the showModal controller attribute.

It closes #61 