### PR TITLE
Updated sample app.js to remove modal div as backdrop doesn't trigger promise.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ var sourcemaps = require('gulp-sourcemaps');
 var express = require('express');
 var connectLivereload = require('connect-livereload');
 var opn = require('opn');
-var karma = require('karma').server;
+var Server = require('karma').Server;
 var header = require('gulp-header');
 
 //  Copies bower dependencies into the samples/vendor folder.
@@ -82,10 +82,10 @@ function notifyLivereload(event) {
 
 //  Test the code.
 gulp.task('test', function (done) {
-  karma.start({
-    configFile: path.join(__dirname, './test/karma.config.js'),
+  new Server({
+    configFile: __dirname + '/test/karma.config.js',
     singleRun: true
-  }, done);
+  }, done).start();
 });
 
 //  Sets up watchers.

--- a/samples/sampleapp.js
+++ b/samples/sampleapp.js
@@ -16,11 +16,12 @@ app.controller('SampleController', ['$scope', 'ModalService', function($scope, M
       modal.element.modal();
       modal.close.then(function(result) {
         $scope.yesNoResult = result ? "You said Yes" : "You said No";
-      },
+      });
       modal.element.on('hidden.bs.modal', function(){
         $('.modal').remove();
-      }));
+      });
     });
+
 
   };
 
@@ -36,10 +37,10 @@ app.controller('SampleController', ['$scope', 'ModalService', function($scope, M
       modal.element.modal();
       modal.close.then(function(result) {
         $scope.complexResult  = "Name: " + result.name + ", age: " + result.age;
-      },
+      });
       modal.element.on('hidden.bs.modal', function(){
         $('.modal').remove();
-      }));
+      });
     });
 
   };
@@ -52,10 +53,11 @@ app.controller('SampleController', ['$scope', 'ModalService', function($scope, M
     }).then(function(modal) {
       modal.close.then(function(result) {
         $scope.customResult = "All good!";
-      },
+      });
       modal.element.on('hidden.bs.modal', function(){
         $('.modal').remove();
-      }));
+      });
+      
     });
 
   };

--- a/samples/sampleapp.js
+++ b/samples/sampleapp.js
@@ -16,7 +16,10 @@ app.controller('SampleController', ['$scope', 'ModalService', function($scope, M
       modal.element.modal();
       modal.close.then(function(result) {
         $scope.yesNoResult = result ? "You said Yes" : "You said No";
-      });
+      },
+      modal.element.on('hidden.bs.modal', function(){
+        $('.modal').remove();
+      }));
     });
 
   };
@@ -33,7 +36,10 @@ app.controller('SampleController', ['$scope', 'ModalService', function($scope, M
       modal.element.modal();
       modal.close.then(function(result) {
         $scope.complexResult  = "Name: " + result.name + ", age: " + result.age;
-      });
+      },
+      modal.element.on('hidden.bs.modal', function(){
+        $('.modal').remove();
+      }));
     });
 
   };
@@ -46,7 +52,10 @@ app.controller('SampleController', ['$scope', 'ModalService', function($scope, M
     }).then(function(modal) {
       modal.close.then(function(result) {
         $scope.customResult = "All good!";
-      });
+      },
+      modal.element.on('hidden.bs.modal', function(){
+        $('.modal').remove();
+      }));
     });
 
   };


### PR DESCRIPTION
I needed to add jQuery Ui Draggable directive to use with this service but, clicking in the backdrop would remove the modal `div` from the DOM. Since the backdrop didn't trigger the promise i added the event that was referenced on #107  and made a tweak. I presume it's not a fancy fix, as the event is called in every situation but it doesn't add any problem, as if it doesn't find a modal if it goes through the promise, but I'm new with this and it solved the issue.

I also made a update in `gulpfile.js` for the new method of testing.