### PR TITLE
Resolving close promise on close instead of after timeout.

### DIFF
--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -81,10 +81,12 @@
             var inputs = {
               $scope: modalScope,
               close: function(result, delay) {
+
+                //  Resolve the 'close' promise.
+                closeDeferred.resolve(result);
+
                 if(delay === undefined || delay === null) delay = 0;
                 $timeout(function() {
-                  //  Resolve the 'close' promise.
-                  closeDeferred.resolve(result);
 
                   //  Let angular remove the element and wait for animations to finish.
                   $animate.leave(modalElement)


### PR DESCRIPTION
The documentation states that the close promise is resolved as soon as the modal close function is called.  It seems to me that it should be resolved as soon as the close function is called instead of inside the delay timeout function.
