### PR TITLE
removed postinstall bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "start": "webpack-dev-server --inline --content-base ./samples",
     "test": "karma start karma.config.js",
     "test-debug": "karma start karma.config.js --no-single-run --browsers Chrome",
-    "coveralls": "cp build/coverage/PhantomJS*/lcov.info lcov.info && node node_modules/coveralls/bin/coveralls.js < lcov.info",
-    "postinstall": "bower install"
+    "coveralls": "cp build/coverage/PhantomJS*/lcov.info lcov.info && node node_modules/coveralls/bin/coveralls.js < lcov.info"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Not everyone is using bower. Npm is used for everything and when someone don't have bower installed installation fails.