### PR TITLE
Fix #90 and #71 at the expense of `$element` injection

### DIFF
--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -86,12 +86,6 @@ module.factory('ModalService', ['$animate', '$document', '$compile', '$controlle
           //  If we have provided any inputs, pass them to the controller.
           if (options.inputs) angular.extend(inputs, options.inputs);
 
-          //  Compile then link the template element, building the actual element.
-          //  Set the $element on the inputs so that it can be injected if required.
-          var linkFn = $compile(template);
-          var modalElement = linkFn(modalScope);
-          inputs.$element = modalElement;
-
           //  Create the controller, explicitly specifying the scope to use.
           var controllerObjBefore = modalScope[options.controllerAs];
           var modalController = $controller(options.controller, inputs, false, options.controllerAs);
@@ -99,6 +93,11 @@ module.factory('ModalService', ['$animate', '$document', '$compile', '$controlle
           if (options.controllerAs && controllerObjBefore) {
             angular.extend(modalController, controllerObjBefore);
           }
+
+          //  Compile then link the template element, building the actual element.
+          //  Set the $element on the inputs so that it can be injected if required.
+          var linkFn = $compile(template);
+          var modalElement = linkFn(modalScope);
 
           //  Finally, append the modal to the dom.
           if (options.appendElement) {

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -21,9 +21,6 @@ describe('controller', () => {
       vm.checkValidity = () => {
         return vm.ExampleForm.$valid;
       }
-    })
-    .controller('ElementController', ($scope, $element) => {
-      $scope.getElement = () => { return $element; };
     });
 
   beforeEach(() => {
@@ -175,24 +172,6 @@ describe('controller', () => {
       //  Fields defined on the controller instance should be on the
       //  controller on the scope.
       expect(modal.scope.futurama.character).toBe('Fry');
-
-    });
-
-    $httpBackend.flush();
-
-  });
-
-  it('should inject the modal element into the controller', () => {
-
-    $httpBackend.expectGET('some/controllertemplate.html');
-
-    ModalService.showModal({
-      controller: 'ElementController',
-      templateUrl: 'some/controllertemplate.html'
-    }).then((modal) => {
-
-      //  The controller should be on the scope.
-      expect(modal.scope.getElement()).not.toBeUndefined();
 
     });
 


### PR DESCRIPTION
If the controller is instantiated after compiling and linking, any directives included in the model template won't have access to controller input values.

For example, take a modal template which includes a `foo` directive, `<foo bar="vm.inputValue"></foo>`. If compile and link functions are executed first, then `foo`'s controller is instantiated during before compilation.

However, since the modal controller is instantiated in code *after* the linking, the `inputValue` is undefined. This makes it impossible to use directives/components which require values from the modal controller.