### PR TITLE
Fixed: Removed remaining modal, backdrop elements on closeModal function

### DIFF
--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -48,12 +48,14 @@ module.factory('ModalService', ['$animate', '$document', '$compile', '$controlle
       while (self.openModals.length) {
         self.openModals[0].close(result, delay);
         self.openModals.splice(0, 1);
-        /*
-          Remove extra modal elements from DOM
-        */
-        angular.element('.modal-backdrop').remove();
-        angular.element('.modal').remove();
       }
+      /*
+        Remove extra modal elements from DOM
+      */
+      var modalBackdropElement = document.querySelector('.modal-backdrop');
+      angular.element(modalBackdropElement).remove();
+      var modalElement = document.querySelector('.modal');
+      angular.element(modalElement).remove();
     };
 
     self.showModal = function(options) {

--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -48,6 +48,11 @@ module.factory('ModalService', ['$animate', '$document', '$compile', '$controlle
       while (self.openModals.length) {
         self.openModals[0].close(result, delay);
         self.openModals.splice(0, 1);
+        /*
+          Remove extra modal elements from DOM
+        */
+        angular.element('.modal-backdrop').remove();
+        angular.element('.modal').remove();
       }
     };
 


### PR DESCRIPTION
Added total removal of elements on modal from DOM.
In some situation the closeModal function didn't remove all modal elements  instead there are some remaining on  DOM especially the backdrop and multiple creation of modal when used on same controller with others.