### PR TITLE
Pass inputs as `inputs` to Controller vs extending inputs object

### DIFF
--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -117,11 +117,11 @@ module.factory('ModalService', ['$animate', '$document', '$compile', '$controlle
                 cleanUpClose(result);
 
               }, delay);
-            }
+            },
+            //  If we have provided any inputs, pass them to the controller as `inputs`
+            //  This allows inputs to be optional
+            inputs: options.inputs || null
           };
-
-          //  If we have provided any inputs, pass them to the controller.
-          if (options.inputs) angular.extend(inputs, options.inputs);
 
           //  Compile then link the template element, building the actual element.
           //  Set the $element on the inputs so that it can be injected if required.


### PR DESCRIPTION
Currently, the user-defined _options.inputs_ object is extended over the _inputs_ object used by the service to inject dependencies into the controller. However, this means each input must be declared explicitly in the controller definition. If a defined input is then left out, angular throws an error since the injected variable is undefined.

Use case: I want to use default language within the modal controller, but allow an override in specific cases. The only way to get around this is to pass each defined input as _null_.

I propose that the _inputs_ be passed in one object to the controller to simplify the interface.