### PR TITLE
feat: wrapper option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ The `showModal` function takes an object with these fields:
 * `bodyClass`: Optional. The custom css class to append to the body while the modal is open (optional, useful when not using Bootstrap).
 * `preClose`: Optional. A function which will be called before the process of closing a modal starts. The signature is `function preClose(modal, result, delay)`. It is provided the `modal` object, the `result` which was passed to `close` and the `delay` which was passed to close.
 * `locationChangeSuccess`: Optional. Allows the closing of the modal when the location changes to be configured. If no value is set, the modal is closed immediately when the `$locationChangeSuccess` event fires. If `false` is set, event is not fired. If a number `n` is set, then the event fires after `n` milliseconds.
+* `wrapper`: Optional. Boolean default to `false`. If true, wrap the template in a div.
+* `wrapperClass`: Optional. String default to `modal-wrapper`. Relative `wrapper`
+  option, define the class of the wrapper element.
 
 #### The Modal Object
 

--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -69,6 +69,9 @@ module.factory('ModalService', ['$animate', '$document', '$compile', '$controlle
       //  Get the actual html of the template.
       getTemplate(options.template, options.templateUrl)
         .then(function(template) {
+          if (options.wrapper) {
+            template = `<div class="${options.wrapperClass || 'modal-wrapper'}">${template}</div>`
+          }
 
           //  The main modal object we will build.
           var modal = {};


### PR DESCRIPTION
Add a simple wrapper option to encapsulate the template in a div.

I find it useful to manage dynamic modal based on routes (like my own use case), and not have to manage a third part element with appendElement option.

I'm open to discussions (since it's my first contact with you 🤗)