### PR TITLE
Do not close a second time if close() has already been called

### DIFF
--- a/dst/angular-modal-service.js
+++ b/dst/angular-modal-service.js
@@ -143,6 +143,8 @@
 	        //  helpful if there are closing animations which must finish first.
 	        var closeDeferred = $q.defer();
 	        var closedDeferred = $q.defer();
+	        var hasAlreadyBeenClosed = false;
+
 	        var inputs = {
 	          $scope: modalScope,
 	          close: function close(result, delay) {
@@ -150,6 +152,11 @@
 	            if (typeof options.preClose === 'function') options.preClose(modal, result, delay);
 	
 	            if (delay === undefined || delay === null) delay = 0;
+	            if (hasAlreadyBeenClosed) {
+	              return;
+	            }
+	            hasAlreadyBeenClosed = true;
+
 	            $timeout(function () {
 	
 	              cleanUpClose(result);

--- a/src/angular-modal-service.js
+++ b/src/angular-modal-service.js
@@ -105,6 +105,8 @@ module.factory('ModalService', ['$animate', '$document', '$compile', '$controlle
           //  helpful if there are closing animations which must finish first.
           var closeDeferred = $q.defer();
           var closedDeferred = $q.defer();
+          var hasAlreadyBeenClosed = false;
+
           var inputs = {
             $scope: modalScope,
             close: function(result, delay) {
@@ -112,6 +114,11 @@ module.factory('ModalService', ['$animate', '$document', '$compile', '$controlle
               if (typeof options.preClose === 'function') options.preClose(modal, result, delay);
 
               if (delay === undefined || delay === null) delay = 0;
+              if (hasAlreadyBeenClosed) {
+                return;
+              }
+              hasAlreadyBeenClosed = true;
+
               $timeout(function() {
 
                 cleanUpClose(result);


### PR DESCRIPTION
In testing we found that when closing a modal twice (clicking save closes our modal as well as clicking outside of the modal) the deferreds we were resolving were nulled out the first time and the second time we tried to resolve them an error would be thrown. 

In order to no longer receive this error, we want to prevent the cleanupClose() method from being called a second time if it was already called.